### PR TITLE
Do not display shadow halves of bidirectional links

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "pegjs": "~0.9.0",
     "underscore": "~1.8.3",
     "webcola": "~3.1.0",
-    "clique": "013c4ba74946b3e07830d8ca6401882330282676"
+    "clique": "b81f077e548cec7782bf7d90a11e6c99c810f417"
   }
 }


### PR DESCRIPTION
This is implemented by updating to a fixed version of Clique.
