### PR TITLE
Context menus for nodes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "pegjs": "~0.9.0",
     "underscore": "~1.8.3",
     "webcola": "~3.1.0",
-    "clique": "b1386950a5d357eeb4e0aba2481250f63c933e7a"
+    "clique": "1a04fca355fc2abcdc8c78af5e6e410f4971e1b3"
   }
 }

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -108,3 +108,6 @@ body
             .row
                 .col-md-12
                     label #[input(type="checkbox")#textmode] Display text labels
+
+    #contextmenu.dropdown.clearfix(style="position: absolute; display: none")
+        ul.dropdown-menu(role="menu" ara-labelledby="dropdownMenu" style="display: block; position: static; margin-bottom: 5px")

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -111,3 +111,9 @@ body
 
     #contextmenu.dropdown.clearfix(style="position: absolute; display: none")
         ul.dropdown-menu(role="menu" ara-labelledby="dropdownMenu" style="display: block; position: static; margin-bottom: 5px")
+            li.dropdown-header.nodelabel
+            li #[a.context-hide(href="#") Hide]
+            li #[a.context-delete(href="#") Delete]
+            li #[a.context-ungroup(href="#") Ungroup]
+            li #[a.context-expand(href="#") Expand]
+            li #[a.context-collapse(href="#") Collapse]

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -147,6 +147,7 @@ $(function () {
     var launch = function (_cfg) {
         var graph,
             view,
+            ungroup,
             info,
             linkInfo,
             colormap;
@@ -324,41 +325,68 @@ $(function () {
             d3.select(view.el)
                 .selectAll("g.node")
                 .on("contextmenu", function (d) {
-                    var left,
+                    var cm = d3.select("#contextmenu"),
+                        ul = cm.select("ul"),
+                        node = graph.adapter.getMutator(d.key),
+                        left,
                         top;
 
                     left = getMenuPosition(d3.event.clientX, "width", "scrollLeft");
                     top = getMenuPosition(d3.event.clientY, "height", "scrollTop");
 
+                    cm.select("ul")
+                        .select("li.nodelabel")
+                        .text(d.data.label);
+
+                    ul.select("a.context-hide")
+                        .on("click", _.bind(clique.view.SelectionInfo.hideNode, info, node));
+
+                    ul.select("a.context-ungroup")
+                        .style("display", d.data.grouped ? null : "none")
+                        .on("click", _.bind(ungroup, info, node));
+
+                    ul.select("a.context-expand")
+                        .on("click", _.bind(clique.view.SelectionInfo.expandNode, info, node));
+
+                    ul.select("a.context-collapse")
+                        .on("click", _.bind(clique.view.SelectionInfo.collapseNode, info, node));
+
                     $.getJSON(cfg.intentService, {
                         user: d.data.label
                     }).then(function (apps) {
-                        var cm = d3.select("#contextmenu");
-
                         apps = _.map(apps, function (data, app) {
                             return _.extend(data, {name: app});
                         });
 
                         cm.select("ul")
-                            .selectAll("li")
+                            .selectAll("li.external")
                             .remove();
 
-                        cm.select("ul")
-                            .selectAll("li")
-                            .data(apps)
-                            .enter()
-                            .append("li")
-                            .append("a")
-                            .attr("tabindex", -1)
-                            .attr("href", "#")
-                            .text(function (d) {
-                                return d.name;
-                            })
-                            .on("click", function (d) {
-                                window.open(d.user, "_blank");
+                        if (_.size(apps) > 0) {
+                            cm.select("ul")
+                                .append("li")
+                                .classed("external", true)
+                                .classed("dropdown-header", true)
+                                .text("External Applications");
 
-                                $cm.hide();
-                            });
+                            cm.select("ul")
+                                .selectAll("li.external")
+                                .data(apps)
+                                .enter()
+                                .append("li")
+                                .classed("external", true)
+                                .append("a")
+                                .attr("tabindex", -1)
+                                .attr("href", "#")
+                                .text(function (d) {
+                                    return d.name;
+                                })
+                                .on("click", function (d) {
+                                    window.open(d.user, "_blank");
+
+                                    $cm.hide();
+                                });
+                        }
 
                         $cm.show()
                             .css({
@@ -374,6 +402,65 @@ $(function () {
                     $cm.hide();
                 });
         });
+
+        ungroup = function (node) {
+            var fromLinks,
+                toLinks,
+                restoredNodes;
+
+            // Get all links involving the group node.
+            fromLinks = this.graph.adapter.findLinks({
+                source: node.key()
+            });
+
+            toLinks = this.graph.adapter.findLinks({
+                target: node.key()
+            });
+
+            $.when(fromLinks, toLinks).then(_.bind(function (from, to) {
+                var inclusion,
+                    reqs;
+
+                // Find the "inclusion" links originating from the
+                // group node.
+                inclusion = _.filter(from, function (link) {
+                    return link.getData("grouping");
+                });
+
+                // Store the node keys associated to these links.
+                restoredNodes = _.invoke(inclusion, "target");
+
+                // Delete all the links.
+                reqs = _.map(from.concat(to), _.bind(function (link) {
+                    this.graph.adapter.destroyLink(link.key());
+                }, this));
+
+                return $.apply($, reqs);
+            }, this)).then(_.bind(function () {
+                // Remove the node from the graph.
+                this.graph.removeNode(node);
+
+                // Delete the node itself.
+                return this.graph.adapter.destroyNode(node.key());
+            }, this)).then(_.bind(function () {
+                var reqs;
+
+                // Get mutators for the restored nodes.
+                reqs = _.map(restoredNodes, this.graph.adapter.findNodeByKey, this.graph.adapter);
+
+                return $.when.apply($, reqs);
+            }, this)).then(_.bind(function () {
+                var nodes = _.toArray(arguments);
+
+                // Clear the deleted flag from the nodes.
+                _.each(nodes, function (node) {
+                    node.clearData("deleted");
+                }, this);
+
+                // Add the nodes to the graph.
+                this.graph.addNodes(nodes);
+            }, this));
+        };
 
         window.info = info = new clique.view.SelectionInfo({
             model: view.selection,
@@ -402,64 +489,7 @@ $(function () {
                     label: "Ungroup",
                     color: "blue",
                     icon: "scissors",
-                    callback: function (node) {
-                        var fromLinks,
-                            toLinks,
-                            restoredNodes;
-
-                        // Get all links involving the group node.
-                        fromLinks = this.graph.adapter.findLinks({
-                            source: node.key()
-                        });
-
-                        toLinks = this.graph.adapter.findLinks({
-                            target: node.key()
-                        });
-
-                        $.when(fromLinks, toLinks).then(_.bind(function (from, to) {
-                            var inclusion,
-                                reqs;
-
-                            // Find the "inclusion" links originating from the
-                            // group node.
-                            inclusion = _.filter(from, function (link) {
-                                return link.getData("grouping");
-                            });
-
-                            // Store the node keys associated to these links.
-                            restoredNodes = _.invoke(inclusion, "target");
-
-                            // Delete all the links.
-                            reqs = _.map(from.concat(to), _.bind(function (link) {
-                                this.graph.adapter.destroyLink(link.key());
-                            }, this));
-
-                            return $.apply($, reqs);
-                        }, this)).then(_.bind(function () {
-                            // Remove the node from the graph.
-                            this.graph.removeNode(node);
-
-                            // Delete the node itself.
-                            return this.graph.adapter.destroyNode(node.key());
-                        }, this)).then(_.bind(function () {
-                            var reqs;
-
-                            // Get mutators for the restored nodes.
-                            reqs = _.map(restoredNodes, this.graph.adapter.findNodeByKey, this.graph.adapter);
-
-                            return $.when.apply($, reqs);
-                        }, this)).then(_.bind(function () {
-                            var nodes = _.toArray(arguments);
-
-                            // Clear the deleted flag from the nodes.
-                            _.each(nodes, function (node) {
-                                node.clearData("deleted");
-                            }, this);
-
-                            // Add the nodes to the graph.
-                            this.graph.addNodes(nodes);
-                        }, this));
-                    },
+                    callback: ungroup,
                     show: function (node) {
                         return node.getData("grouped");
                     }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -291,6 +291,70 @@ $(function () {
             rootColor: "gold"
         });
 
+        view.on("render", function () {
+            var $cm = $("#contextmenu"),
+                getMenuPosition;
+
+            // This returns a position near the mouse pointer, unless it is too
+            // near the right or bottom edge of the window, in which case it
+            // returns a position far enough inside the window to display the
+            // menu in question.
+            getMenuPosition = function (mouse, direction, scrollDir) {
+                var win = $(window)[direction](),
+                    scroll = $(window)[scrollDir](),
+                    menu = $("#contextmenu")[direction](),
+                    position = mouse + scroll;
+
+                if (mouse + menu > win && menu < mouse) {
+                    position -= menu;
+                }
+
+                return position;
+            };
+
+            // Attach a contextmenu action to all the nodes - it populates the
+            // menu element with appropriate data, then shows it at the
+            // appropriate position.
+            d3.select(view.el)
+                .selectAll("g.node")
+                .on("contextmenu", function (d) {
+                    var cm = d3.select("#contextmenu");
+
+                    cm.select("ul")
+                        .selectAll("li")
+                        .remove();
+
+                    cm.select("ul")
+                        .selectAll("li")
+                        .data(_.values(d.data))
+                        .enter()
+                        .append("li")
+                        .append("a")
+                        .attr("tabindex", -1)
+                        .attr("href", "#")
+                        .text(function (d) {
+                            return d;
+                        })
+                        .on("click", function () {
+                            window.open("http://twitter.com", "_blank");
+
+                            $cm.hide();
+                        });
+
+                    $cm.show()
+                        .css({
+                            left: getMenuPosition(d3.event.clientX, "width", "scrollLeft"),
+                            top: getMenuPosition(d3.event.clientY, "height", "scrollTop")
+                        });
+                });
+
+            // Clicking anywhere else will close any open context menu.
+            d3.select(document.body)
+                .on("click.menuhide", function () {
+                    $cm.hide();
+                });
+        });
+
         window.info = info = new clique.view.SelectionInfo({
             model: view.selection,
             el: "#info",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -396,9 +396,15 @@ $(function () {
                     });
                 });
 
-            // Clicking anywhere else will close any open context menu.
+            // Clicking anywhere else will close any open context menu.  Use the
+            // mouseup event (bound to only the left mouse button) to ensure the
+            // menu disappears even on a selection event (which does not
+            // generate a click event).
             d3.select(document.body)
-                .on("click.menuhide", function () {
+                .on("mouseup.menuhide", function () {
+                    if (d3.event.which !== 1) {
+                        return;
+                    }
                     $cm.hide();
                 });
         });

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -71,3 +71,7 @@ html, body
     background-color aliceblue
     position fixed
     top 64px
+
+li.dropdown-header
+    font-weight bold
+    color dimgray


### PR DESCRIPTION
Right-clicking on a node now brings up a context menu.  The menu contains two sections, one for nodal actions:
- hide
- ungroup (if grouped already)
- expand
- collapse
- (delete/undelete is omitted because its a more permanent action; for this the user has to fall back on the button bar on the left)
  and, if there is an intents server available, one for external applications based on the "user" intent.

To enable an intents service, include a field `intentService` in the config object (in the JSON file `anb.json`) that lists a URL serving intents.
